### PR TITLE
[feat] Add .chezmoiroot

### DIFF
--- a/.chezmoiroot
+++ b/.chezmoiroot
@@ -1,0 +1,1 @@
+chezmoi


### PR DESCRIPTION
First step of the mackup -> chezmoi migration. Points chezmoi's source root at a dedicated chezmoi/ directory (currently empty) so the existing dotfiles/ (still managed by mackup) stays untouched during the transition.